### PR TITLE
Fixed retrieval of repos based on different providers + hook updates

### DIFF
--- a/src/main/java/org/eclipsefoundation/git/eca/model/Project.java
+++ b/src/main/java/org/eclipsefoundation/git/eca/model/Project.java
@@ -30,11 +30,15 @@ public class Project {
 	private String name;
 	private List<User> committers;
 	private List<Repo> repos;
+	private List<Repo> gitlabRepos;
+	private List<Repo> githubRepos;
 	private String specWorkingGroup;
 	
 	public Project() {
 		this.committers = new ArrayList<>();
 		this.repos = new ArrayList<>();
+		this.gitlabRepos = new ArrayList<>();
+		this.githubRepos = new ArrayList<>();
 	}
 
 	/**
@@ -83,14 +87,42 @@ public class Project {
 	 * @return the repos
 	 */
 	public List<Repo> getRepos() {
-		return repos;
+		return new ArrayList<>(repos);
 	}
 
 	/**
 	 * @param repos the repos to set
 	 */
 	public void setRepos(List<Repo> repos) {
-		this.repos = repos;
+		this.repos = new ArrayList<>(repos);
+	}
+
+	/**
+	 * @return the gitlabRepos
+	 */
+	public List<Repo> getGitlabRepos() {
+		return new ArrayList<>(gitlabRepos);
+	}
+
+	/**
+	 * @param githubRepos the githubRepos to set
+	 */
+	public void setGithubRepos(List<Repo> githubRepos) {
+		this.githubRepos = new ArrayList<>(githubRepos);
+	}
+
+	/**
+	 * @return the gitlabRepos
+	 */
+	public List<Repo> getGithubRepos() {
+		return new ArrayList<>(githubRepos);
+	}
+
+	/**
+	 * @param gitlabRepos the gitlabRepos to set
+	 */
+	public void setGitlabRepos(List<Repo> gitlabRepos) {
+		this.gitlabRepos = new ArrayList<>(gitlabRepos);
 	}
 
 	/**

--- a/src/main/rb/eca.rb
+++ b/src/main/rb/eca.rb
@@ -51,7 +51,7 @@ json_data = {
   :commits => processed_git_data
 }
 ## Generate request
-response = HTTParty.post("http://172.21.0.1:8083/git/eca", :body => MultiJson.dump(json_data), :headers => { 'Content-Type' => 'application/json' })
+response = HTTParty.post("https://api.eclipse.org/git/eca", :body => MultiJson.dump(json_data), :headers => { 'Content-Type' => 'application/json' })
 ## convert request to hash map
 parsed_response = MultiJson.load(response.body)
 

--- a/src/test/java/org/eclipsefoundation/git/eca/api/MockProjectsAPI.java
+++ b/src/test/java/org/eclipsefoundation/git/eca/api/MockProjectsAPI.java
@@ -58,7 +58,7 @@ public class MockProjectsAPI implements ProjectsAPI {
 		p1.setName("Sample project");
 		p1.setProjectId("sample.proj");
 		p1.setSpecWorkingGroup(null);
-		p1.setRepos(Arrays.asList(r1, r2));
+		p1.setGithubRepos(Arrays.asList(r1, r2));
 		p1.setCommitters(Arrays.asList(u1, u2));
 		src.add(p1);
 
@@ -66,7 +66,7 @@ public class MockProjectsAPI implements ProjectsAPI {
 		p2.setName("Prototype thing");
 		p2.setProjectId("sample.proto");
 		p2.setSpecWorkingGroup(null);
-		p2.setRepos(Arrays.asList(r3));
+		p2.setGithubRepos(Arrays.asList(r3));
 		p2.setCommitters(Arrays.asList(u2));
 		src.add(p2);
 
@@ -74,7 +74,7 @@ public class MockProjectsAPI implements ProjectsAPI {
 		p3.setName("Spec project");
 		p3.setProjectId("spec.proj");
 		p3.setSpecWorkingGroup("proj1");
-		p3.setRepos(Arrays.asList(r4));
+		p3.setGithubRepos(Arrays.asList(r4));
 		p3.setCommitters(Arrays.asList(u1, u2));
 		src.add(p3);
 	}


### PR DESCRIPTION
Updated rb hook for gitlab to use production endpoint since it is live.
Added gitlab + github repo members of the Project object. RElies on
changes that are currently in staging. Changed logic for retrieving
projects to contextually change where it looks for repositories based on
the request provider.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>