### PR TITLE
Updated projects to properly fetch paginated results+precache on start

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,10 +14,10 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<quarkus-plugin.version>1.1.1.Final</quarkus-plugin.version>
+		<quarkus-plugin.version>1.3.0.Final</quarkus-plugin.version>
 		<quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
 		<quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-		<quarkus.platform.version>1.1.1.Final</quarkus.platform.version>
+		<quarkus.platform.version>1.3.0.Final</quarkus.platform.version>
 		<surefire-plugin.version>2.22.1</surefire-plugin.version>
 		<sonar.sources>src/main</sonar.sources>
 		<sonar.tests>src/test</sonar.tests>

--- a/src/main/java/org/eclipsefoundation/git/eca/api/ProjectsAPI.java
+++ b/src/main/java/org/eclipsefoundation/git/eca/api/ProjectsAPI.java
@@ -14,6 +14,7 @@ import java.util.List;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.eclipsefoundation.git.eca.model.Project;
@@ -37,5 +38,5 @@ public interface ProjectsAPI {
 	 */
 	@GET
 	@Produces("application/json")
-	List<Project> getProject();
+	List<Project> getProject(@QueryParam("page") int page, @QueryParam("pagesize") int pageSize);
 }

--- a/src/main/java/org/eclipsefoundation/git/eca/config/SecretConfigSource.java
+++ b/src/main/java/org/eclipsefoundation/git/eca/config/SecretConfigSource.java
@@ -40,6 +40,7 @@ public class SecretConfigSource implements ConfigSource {
 	private Map<String, String> secrets;
 
 	@Override
+	@SuppressWarnings({"rawtypes", "unchecked"})
 	public Map<String, String> getProperties() {
 		if (secrets == null) {
 			this.secrets = new HashMap<>();

--- a/src/main/java/org/eclipsefoundation/git/eca/service/ProjectsService.java
+++ b/src/main/java/org/eclipsefoundation/git/eca/service/ProjectsService.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (C) 2020 Eclipse Foundation
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package org.eclipsefoundation.git.eca.service;
+
+import java.util.List;
+
+import org.eclipsefoundation.git.eca.model.Project;
+
+/**
+ * Intermediate layer between resource and API layers that handles retrieval of
+ * all projects and caching of that data for availability purposes.
+ * 
+ * @author Martin Lowe
+ *
+ */
+public interface ProjectsService {
+
+	/**
+	 * Retrieves all currently available projects from cache if available, otherwise
+	 * going to API to retrieve a fresh copy of the data.
+	 * 
+	 * @return list of projects available from API.
+	 */
+	List<Project> getProjects();
+}

--- a/src/main/java/org/eclipsefoundation/git/eca/service/impl/PagintationProjectsService.java
+++ b/src/main/java/org/eclipsefoundation/git/eca/service/impl/PagintationProjectsService.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (C) 2020 Eclipse Foundation
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package org.eclipsefoundation.git.eca.service.impl;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.eclipsefoundation.git.eca.api.ProjectsAPI;
+import org.eclipsefoundation.git.eca.model.Project;
+import org.eclipsefoundation.git.eca.service.ProjectsService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+import io.quarkus.runtime.Startup;
+
+/**
+ * Projects service implementation that handles pagination of data manually, as
+ * well as makes use of a loading cache to have data be always available with as
+ * little latency to the user as possible.
+ * 
+ * @author Martin Lowe
+ */
+@Startup
+@ApplicationScoped
+public class PagintationProjectsService implements ProjectsService {
+	private static final Logger LOGGER = LoggerFactory.getLogger(PagintationProjectsService.class);
+
+	@Inject
+	@RestClient
+	ProjectsAPI projects;
+	// this class has a separate cache as this data is long to load and should be
+	// always available.
+	LoadingCache<String, List<Project>> internalCache;
+
+	/**
+	 * Initializes the internal loader cache and pre-populates the data with the one
+	 * available key. If more than one key is used, eviction of previous results
+	 * will happen and create degraded performance.
+	 */
+	@PostConstruct
+	public void init() {
+		// set up the internal cache
+		this.internalCache = CacheBuilder.newBuilder().maximumSize(1).refreshAfterWrite(3600, TimeUnit.SECONDS)
+				.build(new CacheLoader<String, List<Project>>() {
+					@Override
+					public List<Project> load(String key) throws Exception {
+						return getProjectsInternal();
+					}
+				});
+
+		// pre-cache the projects to reduce load time for other users
+		LOGGER.debug("Starting pre-cache of projects");
+		if (getProjects() == null) {
+			LOGGER.warn(
+					"Unable to populate pre-cache for Eclipse projects. Calls may experience degraded performance.");
+		}
+		LOGGER.debug("Completed pre-cache of projects assets");
+	}
+
+	@Override
+	public List<Project> getProjects() {
+		try {
+			return internalCache.get("projects");
+		} catch (ExecutionException e) {
+			throw new RuntimeException("Could not load Eclipse projects", e);
+		}
+	}
+
+	/**
+	 * Logic for retrieving projects from API. Will loop until there are no more
+	 * projects to be found
+	 * 
+	 * @return list of projects for the
+	 */
+	private List<Project> getProjectsInternal() {
+		int page = 0;
+		int pageSize = 100;
+		List<Project> out = new LinkedList<>();
+		List<Project> in;
+		do {
+			page++;
+			in = projects.getProject(page, pageSize);
+			out.addAll(in);
+		} while (in != null && !in.isEmpty());
+		return out;
+
+	}
+
+}

--- a/src/test/java/org/eclipsefoundation/git/eca/api/MockProjectsAPI.java
+++ b/src/test/java/org/eclipsefoundation/git/eca/api/MockProjectsAPI.java
@@ -11,6 +11,7 @@ package org.eclipsefoundation.git.eca.api;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.PostConstruct;
@@ -80,8 +81,8 @@ public class MockProjectsAPI implements ProjectsAPI {
 	}
 
 	@Override
-	public List<Project> getProject() {
-		return new ArrayList<>(src);
+	public List<Project> getProject(int page, int pageSize) {
+		return page == 1 ? new ArrayList<>(src) : Collections.emptyList();
 	}
 
 }


### PR DESCRIPTION
Added layer between validation and projects API layer. New service for
pagination of projects. This uses manually incrementing pages rather
than using link headers. This is not easily done within the RESTeasy API
builder paradigm, and will be taken as technical debt to fix. Added
separate cache layer to solve issue with long load times and always
available data with Loading rather than on demand cache.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>