### PR TITLE
Added GL HOOK error string to eca ruby script

### DIFF
--- a/src/main/rb/eca.rb
+++ b/src/main/rb/eca.rb
@@ -72,7 +72,7 @@ commit_keys.each do |key|
     end
     puts "\n"
     commit_status['errors'].each do |error|
-      puts "ERROR: #{error['message']}"
+      puts "GL-HOOK-ERR: #{error['message']}"
     end
     puts "\n\n"
   end


### PR DESCRIPTION
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>