### PR TITLE
Fix for timeouts in the GitLab ECA rb pre-recieve script

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0"?>
-<project
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-	xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipsefoundation</groupId>
 	<artifactId>git-eca</artifactId>
@@ -14,7 +12,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<quarkus-plugin.version>1.3.0.Final</quarkus-plugin.version>
+		<quarkus-plugin.version>1.3.1.Final</quarkus-plugin.version>
 		<quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
 		<quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
 		<quarkus.platform.version>1.3.0.Final</quarkus.platform.version>
@@ -59,6 +57,10 @@
 		<dependency>
 			<groupId>io.quarkus</groupId>
 			<artifactId>quarkus-rest-client</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-smallrye-context-propagation</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.github.scribejava</groupId>

--- a/src/main/java/org/eclipsefoundation/git/eca/resource/mapper/RuntimeMapper.java
+++ b/src/main/java/org/eclipsefoundation/git/eca/resource/mapper/RuntimeMapper.java
@@ -1,0 +1,36 @@
+/* Copyright (c) 2019 Eclipse Foundation and others.
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Public License 2.0
+ * which is available at http://www.eclipse.org/legal/epl-v20.html,
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipsefoundation.git.eca.resource.mapper;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Catch-all exception mapper to ensure that any error thrown by the service
+ * will log the error and quit out safely while limiting the response to a
+ * simple error.
+ * 
+ * @author Martin Lowe
+ *
+ */
+@Provider
+public class RuntimeMapper implements ExceptionMapper<RuntimeException> {
+	private static final Logger LOGGER = LoggerFactory.getLogger(RuntimeMapper.class);
+
+	@Override
+	public Response toResponse(RuntimeException exception) {
+		LOGGER.error(exception.getMessage(), exception);
+		// return an empty response with a server error response
+		return Response.status(Status.INTERNAL_SERVER_ERROR).build();
+	}
+
+}

--- a/src/main/java/org/eclipsefoundation/git/eca/service/impl/PagintationProjectsService.java
+++ b/src/main/java/org/eclipsefoundation/git/eca/service/impl/PagintationProjectsService.java
@@ -18,6 +18,7 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.eclipsefoundation.git.eca.api.ProjectsAPI;
 import org.eclipsefoundation.git.eca.model.Project;
@@ -28,6 +29,8 @@ import org.slf4j.LoggerFactory;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListenableFutureTask;
 
 import io.quarkus.runtime.Startup;
 
@@ -44,6 +47,9 @@ public class PagintationProjectsService implements ProjectsService {
 	private static final Logger LOGGER = LoggerFactory.getLogger(PagintationProjectsService.class);
 
 	@Inject
+	ManagedExecutor exec;
+
+	@Inject
 	@RestClient
 	ProjectsAPI projects;
 	// this class has a separate cache as this data is long to load and should be
@@ -58,11 +64,35 @@ public class PagintationProjectsService implements ProjectsService {
 	@PostConstruct
 	public void init() {
 		// set up the internal cache
-		this.internalCache = CacheBuilder.newBuilder().maximumSize(1).refreshAfterWrite(3600, TimeUnit.SECONDS)
+		this.internalCache = CacheBuilder.newBuilder().maximumSize(1).refreshAfterWrite(120, TimeUnit.SECONDS)
 				.build(new CacheLoader<String, List<Project>>() {
 					@Override
 					public List<Project> load(String key) throws Exception {
 						return getProjectsInternal();
+					}
+
+					/**
+					 * Implementation required for refreshAfterRewrite to be async rather than sync
+					 * and blocking while awaiting for expensive reload to complete.
+					 */
+					@Override
+					public ListenableFuture<List<Project>> reload(String key, List<Project> oldValue) throws Exception {
+						ListenableFutureTask<List<Project>> task = ListenableFutureTask.create(() -> {
+							LOGGER.debug("Retrieving new project data async");
+							List<Project> newProjects = oldValue;
+							try {
+								newProjects = getProjectsInternal();
+							} catch (Exception e) {
+								LOGGER.error(
+										"Error while reloading internal projects data, data will be stale for current cycle.",
+										e);
+							}
+							LOGGER.debug("Done refreshing project values");
+							return newProjects;
+						});
+						// run the task using the Quarkus managed executor
+						exec.execute(task);
+						return task;
 					}
 				});
 

--- a/src/main/java/org/eclipsefoundation/git/eca/service/impl/PagintationProjectsService.java
+++ b/src/main/java/org/eclipsefoundation/git/eca/service/impl/PagintationProjectsService.java
@@ -18,6 +18,7 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.eclipsefoundation.git.eca.api.ProjectsAPI;
@@ -49,6 +50,9 @@ public class PagintationProjectsService implements ProjectsService {
 	@Inject
 	ManagedExecutor exec;
 
+	@ConfigProperty(name = "cache.pagination.refresh-frequency-seconds", defaultValue = "3600")
+	long refreshAfterWrite;
+	
 	@Inject
 	@RestClient
 	ProjectsAPI projects;
@@ -64,7 +68,7 @@ public class PagintationProjectsService implements ProjectsService {
 	@PostConstruct
 	public void init() {
 		// set up the internal cache
-		this.internalCache = CacheBuilder.newBuilder().maximumSize(1).refreshAfterWrite(120, TimeUnit.SECONDS)
+		this.internalCache = CacheBuilder.newBuilder().maximumSize(1).refreshAfterWrite(refreshAfterWrite, TimeUnit.SECONDS)
 				.build(new CacheLoader<String, List<Project>>() {
 					@Override
 					public List<Project> load(String key) throws Exception {


### PR DESCRIPTION
Fixed LoadingCache in projects service to fetch projects async instead
of blocking. Updated RB script with extra error checking. Incremented
Quarkus version to stable 1.3.1.Final from 1.3.0.Final. Added catch-all
runtime exception response mapper to stop HTML response on error pages.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>