### PR TITLE
Update to ECA script to be smarter with reading in commits

### DIFF
--- a/src/main/java/org/eclipsefoundation/git/eca/resource/ValidationResource.java
+++ b/src/main/java/org/eclipsefoundation/git/eca/resource/ValidationResource.java
@@ -224,13 +224,13 @@ public class ValidationResource {
 			// retrieve the email of the Signed-off-by footer
 			String signedOffBy = CommitHelper.getSignedOffByEmail(c);
 			if (signedOffBy != null && signedOffBy.equalsIgnoreCase(eclipseAuthor.getMail())) {
-				addMessage(r, "The author has \"signed-off\" on the contribution.", c.getHash());
+				addMessage(r, "The author has signed-off on the contribution.", c.getHash());
 			} else {
 				addMessage(r,
-						"The author has not \"signed-off\" on the contribution.\n"
+						"The author has not signed-off on the contribution.\n"
 								+ "If there are multiple commits, please ensure that each commit is signed-off.",
 						c.getHash());
-				addError(r, "The contributor must \"sign-off\" on the contribution.", c.getHash(),
+				addError(r, "The contributor must sign-off on the contribution.", c.getHash(),
 						APIStatusCode.ERROR_SIGN_OFF);
 
 			}

--- a/src/main/rb/eca.rb
+++ b/src/main/rb/eca.rb
@@ -5,6 +5,26 @@ require 'json'
 require 'httparty'
 require 'multi_json'
 
+## Process the commit into a hash object that will be posted to the ECA validation service
+def process_commit(sha)
+  commit_parents_raw = `git show -s --format='%P' #{sha}`
+  commit_parents = commit_parents_raw.split(/\s/)
+  return {
+    :author => {
+      :name => `git show -s --format='%an' #{sha}`.force_encoding("utf-8"),
+      :mail => `git show -s --format='%ae' #{sha}`.force_encoding("utf-8"),
+    },
+    :committer => {
+      :name => `git show -s --format='%cn' #{sha}`.force_encoding("utf-8"),
+      :mail => `git show -s --format='%ce' #{sha}`.force_encoding("utf-8"),
+    },
+    :body => `git show -s --format='%B' #{sha}`.force_encoding("utf-8"),
+    :subject => `git show -s --format='%s' #{sha}`.force_encoding("utf-8"),
+    :hash => `git show -s --format='%H' #{sha}`,
+    :parents => commit_parents
+  }
+end
+
 ## read in the access token from secret file
 if (!File.file?("/etc/gitlab/eca-access-token"))
   puts "GL-HOOK-ERR: Internal server error, please contact administrator. Error, secret not found" 
@@ -26,42 +46,6 @@ stdin_args = stdin_raw.split(/\s+/)
 previous_head_commit = stdin_args[0]
 new_head_commit = stdin_args[1]
 
-## Create either a range of commits for existing refs, or the HEAD commit SHA for new refs
-commit_range_declaration = ''
-if (previous_head_commit.match(/^0+$/)) then
-  commit_range_declaration = new_head_commit
-else
-  commit_range_declaration = "#{previous_head_commit}..#{new_head_commit}"
-end
-
-## Retrieve the list of commits for the given range
-git_commit_data = `git rev-list --first-parent #{commit_range_declaration}`
-## Create a list of commits to iterate over from the command line response
-git_commits = git_commit_data.split(/\s+/)
-
-## Process each of the commits, creating a line of formatted JSON data to POST
-processed_git_data = []
-git_commits.each do |commit|
-  ## Get parents separately to post-process string into array format
-  commit_parents_raw = `git show -s --format='%P' #{commit}`
-  commit_parents = commit_parents_raw.split(/\s/)
-  git_commit = {
-    :author => {
-      :name => `git show -s --format='%an' #{commit}`.force_encoding("utf-8"),
-      :mail => `git show -s --format='%ae' #{commit}`.force_encoding("utf-8"),
-    },
-    :committer => {
-      :name => `git show -s --format='%cn' #{commit}`.force_encoding("utf-8"),
-      :mail => `git show -s --format='%ce' #{commit}`.force_encoding("utf-8"),
-    },
-    :body => `git show -s --format='%B' #{commit}`.force_encoding("utf-8"),
-    :subject => `git show -s --format='%s' #{commit}`.force_encoding("utf-8"),
-    :hash => `git show -s --format='%H' #{commit}`,
-    :parents => commit_parents
-  }
-  processed_git_data.push(git_commit)
-end
-
 ## Get the project ID from env var, extracting from pattern 'project-###'
 project_id = ENV['GL_REPOSITORY'][8..-1]
 ## Get data about project from API
@@ -78,14 +62,46 @@ else
   project_url = project_json_data['web_url']
 end
 
+## required for proper cherry-picking of new commits
+default_branch = project_json_data['default_branch']
+default_branch_head_ref = "refs/heads/#{default_branch}"
+
+## Get all commits visible relative to default branch (anything new and not merged in)
+## If merging into a non-default branch this will check more than necessary, but not the whole history (which it was previously)
+diff_git_commits_raw = `git cherry #{default_branch_head_ref} #{new_head_commit}`
+diff_git_commits = diff_git_commits_raw.split(/\n/)
+
+counter = 0
+git_commits = []
+previous_head_idx = 0
+diff_git_commits.each do |commit|
+  if (commit.match(/\+ ?(\S{2,})/)) then
+    ## gsub will return no data for no match, as + indicates new changes and - indicates tracked changes
+    cleaned_commit_sha = commit.gsub(/\+ ?(\S{2,})/, '\1')
+    if (!cleaned_commit_sha.empty?) then
+      git_commits.push(cleaned_commit_sha)
+    end
+    if (cleaned_commit_sha == previous_head_commit) then
+      found_previous_head = true
+      previous_head_idx = counter
+    end
+    counter = counter + 1
+  end
+end
+
+processed_git_data = []
+git_commits[previous_head_idx...].each do |commit|
+  processed_git_data.push(process_commit(commit))
+end
+
 ## Create the JSON payload
 json_data = {
   :repoUrl => project_url,
   :provider => 'gitlab',
   :commits => processed_git_data
 }
-## Generate request
-response = HTTParty.post("https://api.eclipse.org/git/eca", :body => MultiJson.dump(json_data), 
+## Generate request (use gsub to scrub any lingering \n constants)
+response = HTTParty.post("https://api.eclipse.org/git/eca", :body => MultiJson.dump(json_data).gsub('\\n', ''), 
   :headers => { 
     'Content-Type' => 'application/json',
     'charset' => 'utf-8'


### PR DESCRIPTION
Change from using rev-list to cherry for list of commits. Will remove
commits already tracked in default branch from checked commits. This
should prove to be more accurate than rev-list which did not respect
boundaries of branches/tree.

Includes fix for new line characters being randomly added to output
after switch over to using hash objects to store commit data directly.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>