### PR TITLE
Fix typo in message text to remove 'Type'

### DIFF
--- a/src/main/java/org/eclipsefoundation/git/eca/resource/ValidationResource.java
+++ b/src/main/java/org/eclipsefoundation/git/eca/resource/ValidationResource.java
@@ -222,7 +222,7 @@ public class ValidationResource {
         addMessage(
             r,
             "The author does not have a current Eclipse Contributor Agreement (ECA) on file.\n"
-                + "If there are multiple Typecommits, please ensure that each author has a ECA.",
+                + "If there are multiple commits, please ensure that each author has a ECA.",
             c.getHash());
         addError(r, "An Eclipse Contributor Agreement is required.", c.getHash());
       }


### PR DESCRIPTION
Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>