### PR TITLE
Allow for multiple Signed-off-by footer lines to exist in commits

### DIFF
--- a/src/main/java/org/eclipsefoundation/git/eca/helper/CommitHelper.java
+++ b/src/main/java/org/eclipsefoundation/git/eca/helper/CommitHelper.java
@@ -56,18 +56,20 @@ public class CommitHelper {
 	 * processing the body and parsing out the given footer knowing its format.
 	 *
 	 * @param c the commit to retrieve the signed off by footer for
-	 * @return the email address in the Signed-off-by footer, or null if none could
-	 *         be found.
+	 * @return true if an email address matching the authors was found in the signed-off by footer lines
 	 */
-	public static String getSignedOffByEmail(Commit c) {
+	public static boolean getSignedOffByEmail(Commit c) {
 		if (c == null) {
-			return null;
+			return false;
 		}
 		Matcher m = SIGNED_OFF_BY_FOOTER.matcher(c.getBody());
-		if (m.find()) {
-			return m.group(2);
+		while (m.find()) {
+			String signOffEmail = m.group(2);
+			if (signOffEmail != null && signOffEmail.equalsIgnoreCase(c.getAuthor().getMail())) {
+				return true;
+			}
 		}
-		return null;
+		return false;
 	}
 
 	private CommitHelper() {

--- a/src/main/java/org/eclipsefoundation/git/eca/resource/ValidationResource.java
+++ b/src/main/java/org/eclipsefoundation/git/eca/resource/ValidationResource.java
@@ -227,9 +227,8 @@ public class ValidationResource {
         addError(r, "An Eclipse Contributor Agreement is required.", c.getHash());
       }
 
-      // retrieve the email of the Signed-off-by footer
-      String signedOffBy = CommitHelper.getSignedOffByEmail(c);
-      if (signedOffBy != null && signedOffBy.equalsIgnoreCase(eclipseAuthor.getMail())) {
+      // check if one of the signed off by footer lines matches the author email.
+      if (CommitHelper.getSignedOffByEmail(c)) {
         addMessage(r, "The author has signed-off on the contribution.", c.getHash());
       } else {
         addMessage(

--- a/src/test/java/org/eclipsefoundation/git/eca/helper/CommitHelperTest.java
+++ b/src/test/java/org/eclipsefoundation/git/eca/helper/CommitHelperTest.java
@@ -26,14 +26,14 @@ import io.quarkus.test.junit.QuarkusTest;
  *
  */
 @QuarkusTest
-public class CommitHelperTest {
+class CommitHelperTest {
 
 	// represents a known good commit before the start of each test
 	GitUser testUser;
 	Commit baseCommit;
 
 	@BeforeEach
-	public void setup() {
+	void setup() {
 		// basic good user
 		testUser = new GitUser();
 		testUser.setMail("test.user@eclipse-foundation.org");
@@ -52,71 +52,84 @@ public class CommitHelperTest {
 	}
 
 	@Test
-	public void getSignedOffByEmailNullCommit() {
-		Assertions.assertNull(CommitHelper.getSignedOffByEmail(null), "Expected null return for null commit");
+	void getSignedOffByEmailNullCommit() {
+		Assertions.assertFalse(CommitHelper.getSignedOffByEmail(null), "Expected null return for null commit");
 	}
 
 	@Test
-	public void getSignedOffByEmailOnlyFooter() {
+	void getSignedOffByEmailOnlyFooter() {
 		baseCommit.setBody(String.format("Signed-off-by: %s <%s>", testUser.getName(), testUser.getMail()));
-		String actualMail = CommitHelper.getSignedOffByEmail(baseCommit);
-		Assertions.assertEquals(testUser.getMail(), actualMail);
+		boolean actual = CommitHelper.getSignedOffByEmail(baseCommit);
+		Assertions.assertTrue(actual);
+	}
+	@Test
+	void getSignedOffByEmailWithDifferentCasing() {
+		baseCommit.setBody(String.format("Signed-off-by: %s <%s>", testUser.getName(), testUser.getMail().toUpperCase()));
+		boolean actual = CommitHelper.getSignedOffByEmail(baseCommit);
+		Assertions.assertTrue(actual);
 	}
 
 	@Test
-	public void getSignedOffByEmailBodyAndFooter() {
+	void getSignedOffByEmailBodyAndFooter() {
 		baseCommit.setBody(
 				String.format("Sample body content\n\nSigned-off-by: %s <%s>", testUser.getName(), testUser.getMail()));
-		String actualMail = CommitHelper.getSignedOffByEmail(baseCommit);
-		Assertions.assertEquals(testUser.getMail(), actualMail);
+		boolean actualMail = CommitHelper.getSignedOffByEmail(baseCommit);
+		Assertions.assertTrue(actualMail);
 	}
 
 	@Test
-	public void getSignedOffByEmailNoNameFooter() {
+	void getSignedOffByEmailNoNameFooter() {
 		baseCommit.setBody(
 				String.format("Sample body content\n\nSigned-off-by:<%s>", testUser.getMail()));
-		String actualMail = CommitHelper.getSignedOffByEmail(baseCommit);
-		Assertions.assertEquals(testUser.getMail(), actualMail);
+		boolean actual = CommitHelper.getSignedOffByEmail(baseCommit);
+		Assertions.assertTrue(actual);
 	}
 
 	@Test
-	public void getSignedOffByEmailNoBrackets() {
+	void getSignedOffByEmailNoBrackets() {
 		baseCommit.setBody(
 				String.format("Sample body content\n\nSigned-off-by:%s", testUser.getMail()));
-		String actualMail = CommitHelper.getSignedOffByEmail(baseCommit);
-		Assertions.assertNull(actualMail);
+		boolean actual = CommitHelper.getSignedOffByEmail(baseCommit);
+		Assertions.assertFalse(actual);
 	}
 
 	@Test
-	public void getSignedOffByEmailBadFooterName() {
+	void getSignedOffByEmailBadFooterName() {
 		baseCommit.setBody(
 				String.format("Sample body content\n\nSign-off-by: %s <%s>", testUser.getName(), testUser.getMail()));
-		Assertions.assertNull(CommitHelper.getSignedOffByEmail(baseCommit), "Expected no result with typo in footer name");
+		Assertions.assertFalse(CommitHelper.getSignedOffByEmail(baseCommit), "Expected false with typo in footer name");
 		
 		baseCommit.setBody(
 				String.format("Sample body content\n\nSIGNED-OFF-BY: %s <%s>", testUser.getName(), testUser.getMail()));
-		Assertions.assertNull(CommitHelper.getSignedOffByEmail(baseCommit), "Expected no result with bad casing");
+		Assertions.assertFalse(CommitHelper.getSignedOffByEmail(baseCommit), "Expected false with bad casing");
 	}
 
 	@Test
-	public void validateCommitKnownGood() {
+	void getSignedOffByEmailBadAuthorEmail() {
+		baseCommit.setBody(
+				String.format("Sample body content\n\nSigned-off-by: %s <%s>", testUser.getName(), "known_bad@email.org"));
+		Assertions.assertFalse(CommitHelper.getSignedOffByEmail(baseCommit), "Expected false with typo in footer name");
+	}
+
+	@Test
+	void validateCommitKnownGood() {
 		Assertions.assertTrue(CommitHelper.validateCommit(baseCommit), "Expected basic commit to pass validation");
 	}
 	
 	@Test
-	public void validateCommitNullCommit() {
+	void validateCommitNullCommit() {
 		Assertions.assertFalse(CommitHelper.validateCommit(null), "Expected null commit to fail validation");
 	}
 
 	@Test
-	public void validateCommitNoAuthor() {
+	void validateCommitNoAuthor() {
 		baseCommit.setAuthor(null);
 		Assertions.assertFalse(CommitHelper.validateCommit(baseCommit),
 				"Expected basic commit to fail validation w/ no author");
 	}
 
 	@Test
-	public void validateCommitNoAuthorMail() {
+	void validateCommitNoAuthorMail() {
 		GitUser noMail = new GitUser();
 		noMail.setName("Some Name");
 
@@ -126,14 +139,14 @@ public class CommitHelperTest {
 	}
 
 	@Test
-	public void validateCommitNoCommitter() {
+	void validateCommitNoCommitter() {
 		baseCommit.setCommitter(null);
 		Assertions.assertFalse(CommitHelper.validateCommit(baseCommit),
 				"Expected basic commit to fail validation w/ no committer");
 	}
 
 	@Test
-	public void validateCommitNoCommitterMail() {
+	void validateCommitNoCommitterMail() {
 		GitUser noMail = new GitUser();
 		noMail.setName("Some Name");
 
@@ -143,28 +156,28 @@ public class CommitHelperTest {
 	}
 
 	@Test
-	public void validateCommitNoHash() {
+	void validateCommitNoHash() {
 		baseCommit.setHash(null);
 		Assertions.assertFalse(CommitHelper.validateCommit(baseCommit),
 				"Expected basic commit to fail validation w/ no commit hash");
 	}
 
 	@Test
-	public void validateCommitNoBody() {
+	void validateCommitNoBody() {
 		baseCommit.setBody(null);
 		Assertions.assertTrue(CommitHelper.validateCommit(baseCommit),
 				"Expected basic commit to pass validation w/ no body");
 	}
 
 	@Test
-	public void validateCommitNoParents() {
+	void validateCommitNoParents() {
 		baseCommit.setParents(new ArrayList<>());
 		Assertions.assertTrue(CommitHelper.validateCommit(baseCommit),
 				"Expected basic commit to pass validation w/ no parents");
 	}
 
 	@Test
-	public void validateCommitNoSubject() {
+	void validateCommitNoSubject() {
 		baseCommit.setSubject(null);
 		Assertions.assertTrue(CommitHelper.validateCommit(baseCommit),
 				"Expected basic commit to pass validation w/ no subject");

--- a/src/test/java/org/eclipsefoundation/git/eca/resource/ValidationResourceTest.java
+++ b/src/test/java/org/eclipsefoundation/git/eca/resource/ValidationResourceTest.java
@@ -1,12 +1,13 @@
-/*******************************************************************************
- * Copyright (C) 2020 Eclipse Foundation
+/**
+ * Copyright (C) 2020
+ * Eclipse Foundation
+ *
+ * <p>This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License 2.0 which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * <p>SPDX-License-Identifier: EPL-2.0
  * 
- * This program and the accompanying materials are made
- * available under the terms of the Eclipse Public License 2.0
- * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
- ******************************************************************************/
+ */
 package org.eclipsefoundation.git.eca.resource;
 
 import static io.restassured.RestAssured.given;
@@ -30,556 +31,610 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 
 /**
- * Tests for verifying end to end validation via the endpoint. Uses restassured
- * to create pseudo requests, and Mock API endpoints to ensure that all data is
- * kept internal for test checks.
- * 
- * @author Martin Lowe
+ * Tests for verifying end to end validation via the endpoint. Uses restassured to create pseudo
+ * requests, and Mock API endpoints to ensure that all data is kept internal for test checks.
  *
+ * @author Martin Lowe
  */
 @QuarkusTest
 class ValidationResourceTest {
 
-	@Test
-	void validate() throws URISyntaxException {
-		// set up test users
-		GitUser g1 = new GitUser();
-		g1.setName("The Wizard");
-		g1.setMail("code.wiz@important.co");
+  @Test
+  void validate() throws URISyntaxException {
+    // set up test users
+    GitUser g1 = new GitUser();
+    g1.setName("The Wizard");
+    g1.setMail("code.wiz@important.co");
 
-		List<Commit> commits = new ArrayList<>();
-		// create sample commits
-		Commit c1 = new Commit();
-		c1.setAuthor(g1);
-		c1.setCommitter(g1);
-		c1.setBody("Signed-off-by: The Wizard <code.wiz@important.co>");
-		c1.setHash("123456789abcdefghijklmnop");
-		c1.setSubject("All of the things");
-		c1.setParents(Collections.emptyList());
-		commits.add(c1);
-		
-		ValidationRequest vr = new ValidationRequest();
-		vr.setProvider(ProviderType.GITHUB);
-		vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/sample"));
-		vr.setCommits(commits);
-		
-		// test output w/ assertions
-		given()
-			.body(vr)
-			.contentType(ContentType.JSON)
-				.when().post("/eca")
-				.then()
-					.statusCode(200)
-					.body("passed", is(true),
-							"errorCount", is(0));
-	}
+    List<Commit> commits = new ArrayList<>();
+    // create sample commits
+    Commit c1 = new Commit();
+    c1.setAuthor(g1);
+    c1.setCommitter(g1);
+    c1.setBody("Signed-off-by: The Wizard <code.wiz@important.co>");
+    c1.setHash("123456789abcdefghijklmnop");
+    c1.setSubject("All of the things");
+    c1.setParents(Collections.emptyList());
+    commits.add(c1);
 
-	@Test
-	void validateMultipleCommits() throws URISyntaxException {
-		// set up test users
-		GitUser g1 = new GitUser();
-		g1.setName("The Wizard");
-		g1.setMail("code.wiz@important.co");
+    ValidationRequest vr = new ValidationRequest();
+    vr.setProvider(ProviderType.GITHUB);
+    vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/sample"));
+    vr.setCommits(commits);
 
-		GitUser g2 = new GitUser();
-		g2.setName("Grunts McGee");
-		g2.setMail("grunt@important.co");
+    // test output w/ assertions
+    given()
+        .body(vr)
+        .contentType(ContentType.JSON)
+        .when()
+        .post("/eca")
+        .then()
+        .statusCode(200)
+        .body("passed", is(true), "errorCount", is(0));
+  }
 
-		List<Commit> commits = new ArrayList<>();
-		// create sample commits
-		Commit c1 = new Commit();
-		c1.setAuthor(g1);
-		c1.setCommitter(g1);
-		c1.setBody("Signed-off-by: The Wizard <code.wiz@important.co>");
-		c1.setHash("123456789abcdefghijklmnop");
-		c1.setSubject("All of the things");
-		c1.setParents(Collections.emptyList());
-		commits.add(c1);
+  @Test
+  void validateMultipleCommits() throws URISyntaxException {
+    // set up test users
+    GitUser g1 = new GitUser();
+    g1.setName("The Wizard");
+    g1.setMail("code.wiz@important.co");
 
-		Commit c2 = new Commit();
-		c2.setAuthor(g2);
-		c2.setCommitter(g2);
-		c2.setBody("Signed-off-by: Grunts McGee<grunt@important.co>");
-		c2.setHash("c044dca1847c94e709601651339f88a5c82e3cc7");
-		c2.setSubject("Add in feature");
-		c2.setParents(
-				Arrays.asList("46bb69bf6aa4ed26b2bf8c322ae05bef0bcc5c10"));
-		commits.add(c2);
-		
-		ValidationRequest vr = new ValidationRequest();
-		vr.setProvider(ProviderType.GITHUB);
-		vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/sample"));
-		vr.setCommits(commits);
-		
-		// test output w/ assertions
-		given()
-			.body(vr)
-			.contentType(ContentType.JSON)
-				.when().post("/eca")
-				.then()
-					.statusCode(200)
-					.body("passed", is(true),
-							"errorCount", is(0));
-	}
-	
-	@Test
-	void validateMergeCommit() throws URISyntaxException {
-		// set up test users
-		GitUser g1 = new GitUser();
-		g1.setName("Rando Calressian");
-		g1.setMail("rando@nowhere.co");
+    GitUser g2 = new GitUser();
+    g2.setName("Grunts McGee");
+    g2.setMail("grunt@important.co");
 
-		List<Commit> commits = new ArrayList<>();
-		// create sample commits
-		Commit c1 = new Commit();
-		c1.setAuthor(g1);
-		c1.setCommitter(g1);
-		c1.setBody(String.format("Signed-off-by: %s <%s>", g1.getName(), g1.getMail()));
-		c1.setHash("123456789abcdefghijklmnop");
-		c1.setSubject("All of the things");
-		c1.setParents(Arrays.asList("46bb69bf6aa4ed26b2bf8c322ae05bef0bcc5c10", "46bb69bf6aa4ed26b2bf8c322ae05bef0bcc5c11"));
-		commits.add(c1);
-		
-		ValidationRequest vr = new ValidationRequest();
-		vr.setProvider(ProviderType.GITHUB);
-		vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/sample"));
-		vr.setCommits(commits);
-		// test output w/ assertions
-		// No errors expected, should pass as only commit is a valid merge commit
-		given()
-			.body(vr)
-			.contentType(ContentType.JSON)
-				.when().post("/eca")
-				.then()
-					.statusCode(200)
-					.body("passed", is(true),
-							"errorCount", is(0));
-	}
-	
-	@Test
-	void validateCommitNoSignOffCommitter() throws URISyntaxException {
-		// set up test users
-		GitUser g1 = new GitUser();
-		g1.setName("Grunts McGee");
-		g1.setMail("grunt@important.co");
+    List<Commit> commits = new ArrayList<>();
+    // create sample commits
+    Commit c1 = new Commit();
+    c1.setAuthor(g1);
+    c1.setCommitter(g1);
+    c1.setBody("Signed-off-by: The Wizard <code.wiz@important.co>");
+    c1.setHash("123456789abcdefghijklmnop");
+    c1.setSubject("All of the things");
+    c1.setParents(Collections.emptyList());
+    commits.add(c1);
 
-		List<Commit> commits = new ArrayList<>();
-		// create sample commits
-		Commit c1 = new Commit();
-		c1.setAuthor(g1);
-		c1.setCommitter(g1);
-		c1.setBody("");
-		c1.setHash("123456789abcdefghijklmnop");
-		c1.setSubject("All of the things");
-		c1.setParents(Collections.emptyList());
-		commits.add(c1);
-		
-		ValidationRequest vr = new ValidationRequest();
-		vr.setProvider(ProviderType.GITHUB);
-		vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/prototype"));
-		vr.setCommits(commits);
-		
-		// test output w/ assertions
-		// Should be valid as Grunt is a committer on the prototype project
-		given()
-			.body(vr)
-			.contentType(ContentType.JSON)
-				.when().post("/eca")
-				.then()
-					.statusCode(200)
-					.body("passed", is(true),
-							"errorCount", is(0));
-	}
-	
-	@Test
-	void validateCommitNoSignOffNonCommitter() throws URISyntaxException {
-		// set up test users
-		GitUser g1 = new GitUser();
-		g1.setName("The Wizard");
-		g1.setMail("code.wiz@important.co");
+    Commit c2 = new Commit();
+    c2.setAuthor(g2);
+    c2.setCommitter(g2);
+    c2.setBody("Signed-off-by: Grunts McGee<grunt@important.co>");
+    c2.setHash("c044dca1847c94e709601651339f88a5c82e3cc7");
+    c2.setSubject("Add in feature");
+    c2.setParents(Arrays.asList("46bb69bf6aa4ed26b2bf8c322ae05bef0bcc5c10"));
+    commits.add(c2);
 
-		List<Commit> commits = new ArrayList<>();
-		// create sample commits
-		Commit c1 = new Commit();
-		c1.setAuthor(g1);
-		c1.setCommitter(g1);
-		c1.setBody("");
-		c1.setHash("123456789abcdefghijklmnop");
-		c1.setSubject("All of the things");
-		c1.setParents(Collections.emptyList());
-		commits.add(c1);
-		
-		ValidationRequest vr = new ValidationRequest();
-		vr.setProvider(ProviderType.GITHUB);
-		vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/prototype"));
-		vr.setCommits(commits);
-		
-		// test output w/ assertions
-		// Should be invalid as Wizard is not a committer on the prototype project
-		given()
-			.body(vr)
-			.contentType(ContentType.JSON)
-				.when().post("/eca")
-				.then()
-					.statusCode(403)
-					.body("passed", is(false),
-							"errorCount", is(1),
-							"commits.123456789abcdefghijklmnop.errors[0].code", 
-							is(APIStatusCode.ERROR_SIGN_OFF.getValue()));
-	}
-	
-	@Test
-	void validateCommitInvalidSignOff() throws URISyntaxException {
-		// set up test users
-		GitUser g1 = new GitUser();
-		g1.setName("Barshall Blathers");
-		g1.setMail("slom@eclipse-foundation.org");
+    ValidationRequest vr = new ValidationRequest();
+    vr.setProvider(ProviderType.GITHUB);
+    vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/sample"));
+    vr.setCommits(commits);
 
-		List<Commit> commits = new ArrayList<>();
-		// create sample commits
-		Commit c1 = new Commit();
-		c1.setAuthor(g1);
-		c1.setCommitter(g1);
-		c1.setBody(String.format("Signed-off-by: %s <%s>", g1.getName(), "barshallb@personal.co"));
-		c1.setHash("123456789abcdefghijklmnop");
-		c1.setSubject("All of the things");
-		c1.setParents(Collections.emptyList());
-		commits.add(c1);
-		
-		ValidationRequest vr = new ValidationRequest();
-		vr.setProvider(ProviderType.GITHUB);
-		vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/prototype"));
-		vr.setCommits(commits);
-		
-		// test output w/ assertions
-		// Should be invalid as a different email was associated with the footer
-		given()
-			.body(vr)
-			.contentType(ContentType.JSON)
-				.when().post("/eca")
-				.then()
-					.statusCode(403)
-					.body("passed", is(false),
-							"errorCount", is(1),
-							"commits.123456789abcdefghijklmnop.errors[0].code", 
-							is(APIStatusCode.ERROR_SIGN_OFF.getValue()));
-	}
-	@Test
-	void validateCommitSignOffMultipleFooterLines_Last() throws URISyntaxException {
-		// set up test users
-		GitUser g1 = new GitUser();
-		g1.setName("Barshall Blathers");
-		g1.setMail("slom@eclipse-foundation.org");
+    // test output w/ assertions
+    given()
+        .body(vr)
+        .contentType(ContentType.JSON)
+        .when()
+        .post("/eca")
+        .then()
+        .statusCode(200)
+        .body("passed", is(true), "errorCount", is(0));
+  }
 
-		List<Commit> commits = new ArrayList<>();
-		// create sample commits
-		Commit c1 = new Commit();
-		c1.setAuthor(g1);
-		c1.setCommitter(g1);
-		c1.setBody(String.format("Change-Id: 0000000000000001\nSigned-off-by: %s <%s>", g1.getName(), g1.getMail()));
-		c1.setHash("123456789abcdefghijklmnop");
-		c1.setSubject("All of the things");
-		c1.setParents(Collections.emptyList());
-		commits.add(c1);
-		
-		ValidationRequest vr = new ValidationRequest();
-		vr.setProvider(ProviderType.GITHUB);
-		vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/prototype"));
-		vr.setCommits(commits);
-		
-		// test output w/ assertions
-		given()
-			.body(vr)
-			.contentType(ContentType.JSON)
-				.when().post("/eca")
-				.then()
-					.statusCode(200)
-					.body("passed", is(true),
-							"errorCount", is(0));
-	}
+  @Test
+  void validateMergeCommit() throws URISyntaxException {
+    // set up test users
+    GitUser g1 = new GitUser();
+    g1.setName("Rando Calressian");
+    g1.setMail("rando@nowhere.co");
 
-	@Test
-	void validateCommitSignOffMultipleFooterLines_First() throws URISyntaxException {
-		// set up test users
-		GitUser g1 = new GitUser();
-		g1.setName("Barshall Blathers");
-		g1.setMail("slom@eclipse-foundation.org");
+    List<Commit> commits = new ArrayList<>();
+    // create sample commits
+    Commit c1 = new Commit();
+    c1.setAuthor(g1);
+    c1.setCommitter(g1);
+    c1.setBody(String.format("Signed-off-by: %s <%s>", g1.getName(), g1.getMail()));
+    c1.setHash("123456789abcdefghijklmnop");
+    c1.setSubject("All of the things");
+    c1.setParents(
+        Arrays.asList(
+            "46bb69bf6aa4ed26b2bf8c322ae05bef0bcc5c10",
+            "46bb69bf6aa4ed26b2bf8c322ae05bef0bcc5c11"));
+    commits.add(c1);
 
-		List<Commit> commits = new ArrayList<>();
-		// create sample commits
-		Commit c1 = new Commit();
-		c1.setAuthor(g1);
-		c1.setCommitter(g1);
-		c1.setBody(String.format("Signed-off-by: %s <%s>\nChange-Id: 0000000000000001", g1.getName(), g1.getMail()));
-		c1.setHash("123456789abcdefghijklmnop");
-		c1.setSubject("All of the things");
-		c1.setParents(Collections.emptyList());
-		commits.add(c1);
-		
-		ValidationRequest vr = new ValidationRequest();
-		vr.setProvider(ProviderType.GITHUB);
-		vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/prototype"));
-		vr.setCommits(commits);
-		
-		// test output w/ assertions
-		given()
-			.body(vr)
-			.contentType(ContentType.JSON)
-				.when().post("/eca")
-				.then()
-					.statusCode(200)
-					.body("passed", is(true),
-							"errorCount", is(0));
-	}
+    ValidationRequest vr = new ValidationRequest();
+    vr.setProvider(ProviderType.GITHUB);
+    vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/sample"));
+    vr.setCommits(commits);
+    // test output w/ assertions
+    // No errors expected, should pass as only commit is a valid merge commit
+    given()
+        .body(vr)
+        .contentType(ContentType.JSON)
+        .when()
+        .post("/eca")
+        .then()
+        .statusCode(200)
+        .body("passed", is(true), "errorCount", is(0));
+  }
 
-	@Test
-	void validateWorkingGroupSpecAccess() throws URISyntaxException {
-		// set up test users
-		GitUser g1 = new GitUser();
-		g1.setName("The Wizard");
-		g1.setMail("code.wiz@important.co");
+  @Test
+  void validateCommitNoSignOffCommitter() throws URISyntaxException {
+    // set up test users
+    GitUser g1 = new GitUser();
+    g1.setName("Grunts McGee");
+    g1.setMail("grunt@important.co");
 
-		GitUser g2 = new GitUser();
-		g2.setName("Grunts McGee");
-		g2.setMail("grunt@important.co");
+    List<Commit> commits = new ArrayList<>();
+    // create sample commits
+    Commit c1 = new Commit();
+    c1.setAuthor(g1);
+    c1.setCommitter(g1);
+    c1.setBody("");
+    c1.setHash("123456789abcdefghijklmnop");
+    c1.setSubject("All of the things");
+    c1.setParents(Collections.emptyList());
+    commits.add(c1);
 
-		// CASE 1: WG Spec project write access valid
-		List<Commit> commits = new ArrayList<>();
-		// create sample commits
-		Commit c1 = new Commit();
-		c1.setAuthor(g1);
-		c1.setCommitter(g1);
-		c1.setBody("Signed-off-by: The Wizard <code.wiz@important.co>");
-		c1.setHash("123456789abcdefghijklmnop");
-		c1.setSubject("All of the things");
-		c1.setParents(Collections.emptyList());
-		commits.add(c1);
-		
-		ValidationRequest vr = new ValidationRequest();
-		vr.setProvider(ProviderType.GITHUB);
-		vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/tck-proto"));
-		vr.setCommits(commits);
-		
-		// test output w/ assertions
-		// Should be valid as Wizard has spec project write access + is committer
-		given()
-			.body(vr)
-			.contentType(ContentType.JSON)
-				.when().post("/eca")
-				.then()
-					.statusCode(200)
-					.body("passed", is(true),
-							"errorCount", is(0));
-		
-		// CASE 2: No WG Spec proj write access
-		commits = new ArrayList<>();
-		// create sample commits
-		c1 = new Commit();
-		c1.setAuthor(g2);
-		c1.setCommitter(g2);
-		c1.setBody(String.format("Signed-off-by: %s <%s>", g2.getName(), g2.getMail()));
-		c1.setHash("123456789abcdefghijklmnop");
-		c1.setSubject("All of the things");
-		c1.setParents(Arrays.asList("46bb69bf6aa4ed26b2bf8c322ae05bef0bcc5c10"));
-		commits.add(c1);
-		
-		vr = new ValidationRequest();
-		vr.setProvider(ProviderType.GITHUB);
-		vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/tck-proto"));
-		vr.setCommits(commits);
+    ValidationRequest vr = new ValidationRequest();
+    vr.setProvider(ProviderType.GITHUB);
+    vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/prototype"));
+    vr.setCommits(commits);
 
-		// test output w/ assertions
-		// Should be invalid as Grunt does not have spec project write access
-		given()
-			.body(vr)
-			.contentType(ContentType.JSON)
-				.when().post("/eca")
-				.then()
-					.statusCode(403)
-					.body("passed", is(false),
-							"errorCount", is(1),
-							"commits.123456789abcdefghijklmnop.errors[0].code", 
-							is(APIStatusCode.ERROR_SPEC_PROJECT.getValue()));
-	}
-	
-	@Test
-	void validateProxyCommitPush() throws URISyntaxException {
-		// set up test users
-		GitUser g1 = new GitUser();
-		g1.setName("The Wizard");
-		g1.setMail("code.wiz@important.co");
+    // test output w/ assertions
+    // Should be valid as Grunt is a committer on the prototype project
+    given()
+        .body(vr)
+        .contentType(ContentType.JSON)
+        .when()
+        .post("/eca")
+        .then()
+        .statusCode(200)
+        .body("passed", is(true), "errorCount", is(0));
+  }
 
-		GitUser g2 = new GitUser();
-		g2.setName("Barshall Blathers");
-		g2.setMail("slom@eclipse-foundation.org");
+  @Test
+  void validateCommitNoSignOffNonCommitter() throws URISyntaxException {
+    // set up test users
+    GitUser g1 = new GitUser();
+    g1.setName("The Wizard");
+    g1.setMail("code.wiz@important.co");
 
-		// CASE 1: Committer pushing for non-committer author
-		List<Commit> commits = new ArrayList<>();
-		// create sample commits
-		Commit c1 = new Commit();
-		c1.setAuthor(g2);
-		c1.setCommitter(g1);
-		c1.setBody(String.format("Signed-off-by: %s <%s>", g2.getName(), g2.getMail()));
-		c1.setHash("123456789abcdefghijklmnop");
-		c1.setSubject("All of the things");
-		c1.setParents(Collections.emptyList());
-		commits.add(c1);
-		
-		ValidationRequest vr = new ValidationRequest();
-		vr.setProvider(ProviderType.GITHUB);
-		vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/tck-proto"));
-		vr.setCommits(commits);
-		
-		// test output w/ assertions
-		// Should be valid as Wizard is a committer on proj
-		given()
-			.body(vr)
-			.contentType(ContentType.JSON)
-				.when().post("/eca")
-				.then()
-					.statusCode(200)
-					.body("passed", is(true),
-							"errorCount", is(0));
-		
-		// CASE 2: Non-committer pushing for non-committer author
-		commits = new ArrayList<>();
-		// create sample commits
-		c1 = new Commit();
-		c1.setAuthor(g2);
-		c1.setCommitter(g1);
-		c1.setBody(String.format("Signed-off-by: %s <%s>", g2.getName(), g2.getMail()));
-		c1.setHash("123456789abcdefghijklmnop");
-		c1.setSubject("All of the things");
-		c1.setParents(Arrays.asList("46bb69bf6aa4ed26b2bf8c322ae05bef0bcc5c10"));
-		commits.add(c1);
-		
-		vr = new ValidationRequest();
-		vr.setProvider(ProviderType.GITHUB);
-		vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/prototype"));
-		vr.setCommits(commits);
+    List<Commit> commits = new ArrayList<>();
+    // create sample commits
+    Commit c1 = new Commit();
+    c1.setAuthor(g1);
+    c1.setCommitter(g1);
+    c1.setBody("");
+    c1.setHash("123456789abcdefghijklmnop");
+    c1.setSubject("All of the things");
+    c1.setParents(Collections.emptyList());
+    commits.add(c1);
 
-		// test output w/ assertions
-		// Should be invalid as Wizard is not a committer on proj
-		given()
-			.body(vr)
-			.contentType(ContentType.JSON)
-				.when().post("/eca")
-				.then()
-					.statusCode(403)
-					.body("passed", is(false),
-							"errorCount", is(1));
-	}
+    ValidationRequest vr = new ValidationRequest();
+    vr.setProvider(ProviderType.GITHUB);
+    vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/prototype"));
+    vr.setCommits(commits);
 
-	@Test
-	void validateNoECA() throws URISyntaxException {
-		// set up test users
-		GitUser g1 = new GitUser();
-		g1.setName("Newbie Anon");
-		g1.setMail("newbie@important.co");
+    // test output w/ assertions
+    // Should be invalid as Wizard is not a committer on the prototype project
+    given()
+        .body(vr)
+        .contentType(ContentType.JSON)
+        .when()
+        .post("/eca")
+        .then()
+        .statusCode(403)
+        .body(
+            "passed",
+            is(false),
+            "errorCount",
+            is(1),
+            "commits.123456789abcdefghijklmnop.errors[0].code",
+            is(APIStatusCode.ERROR_SIGN_OFF.getValue()));
+  }
 
-		List<Commit> commits = new ArrayList<>();
-		// create sample commits
-		Commit c1 = new Commit();
-		c1.setAuthor(g1);
-		c1.setCommitter(g1);
-		c1.setBody(String.format("Signed-off-by: %s <%s>", g1.getName(), g1.getMail()));
-		c1.setHash("123456789abcdefghijklmnop");
-		c1.setSubject("All of the things");
-		c1.setParents(Arrays.asList("46bb69bf6aa4ed26b2bf8c322ae05bef0bcc5c10"));
-		commits.add(c1);
-		
-		ValidationRequest vr = new ValidationRequest();
-		vr.setProvider(ProviderType.GITHUB);
-		vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/sample"));
-		vr.setCommits(commits);
-		// test output w/ assertions
-		// Error should be singular + that there's no ECA on file
-		// Status 403 (forbidden) is the standard return for invalid requests
-		given()
-			.body(vr)
-			.contentType(ContentType.JSON)
-				.when().post("/eca")
-				.then()
-					.statusCode(403)
-					.body("passed", is(false),
-							"errorCount", is(1));
-	}
-	
-	@Test
-	void validateAuthorNoEclipseAccount() throws URISyntaxException {
-		// set up test users
-		GitUser g1 = new GitUser();
-		g1.setName("Rando Calressian");
-		g1.setMail("rando@nowhere.co");
-		
-		GitUser g2 = new GitUser();
-		g2.setName("Grunts McGee");
-		g2.setMail("grunt@important.co");
+  @Test
+  void validateCommitInvalidSignOff() throws URISyntaxException {
+    // set up test users
+    GitUser g1 = new GitUser();
+    g1.setName("Barshall Blathers");
+    g1.setMail("slom@eclipse-foundation.org");
 
-		List<Commit> commits = new ArrayList<>();
-		// create sample commits
-		Commit c1 = new Commit();
-		c1.setAuthor(g1);
-		c1.setCommitter(g2);
-		c1.setBody(String.format("Signed-off-by: %s <%s>", g1.getName(), g1.getMail()));
-		c1.setHash("123456789abcdefghijklmnop");
-		c1.setSubject("All of the things");
-		c1.setParents(Arrays.asList("46bb69bf6aa4ed26b2bf8c322ae05bef0bcc5c10"));
-		commits.add(c1);
-		
-		ValidationRequest vr = new ValidationRequest();
-		vr.setProvider(ProviderType.GITHUB);
-		vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/sample"));
-		vr.setCommits(commits);
-		// test output w/ assertions
-		// Error should be singular + that there's no Eclipse Account on file for author
-		// Status 403 (forbidden) is the standard return for invalid requests
-		given()
-			.body(vr)
-			.contentType(ContentType.JSON)
-				.when().post("/eca")
-				.then()
-					.statusCode(403)
-					.body("passed", is(false),
-							"errorCount", is(1));
-	}
-	
-	@Test
-	void validateCommitterNoEclipseAccount() throws URISyntaxException {
-		// set up test users
-		GitUser g1 = new GitUser();
-		g1.setName("Rando Calressian");
-		g1.setMail("rando@nowhere.co");
-		
-		GitUser g2 = new GitUser();
-		g2.setName("Grunts McGee");
-		g2.setMail("grunt@important.co");
+    List<Commit> commits = new ArrayList<>();
+    // create sample commits
+    Commit c1 = new Commit();
+    c1.setAuthor(g1);
+    c1.setCommitter(g1);
+    c1.setBody(String.format("Signed-off-by: %s <%s>", g1.getName(), "barshallb@personal.co"));
+    c1.setHash("123456789abcdefghijklmnop");
+    c1.setSubject("All of the things");
+    c1.setParents(Collections.emptyList());
+    commits.add(c1);
 
-		List<Commit> commits = new ArrayList<>();
-		// create sample commits
-		Commit c1 = new Commit();
-		c1.setAuthor(g2);
-		c1.setCommitter(g1);
-		c1.setBody(String.format("Signed-off-by: %s <%s>", g2.getName(), g2.getMail()));
-		c1.setHash("123456789abcdefghijklmnop");
-		c1.setSubject("All of the things");
-		c1.setParents(Arrays.asList("46bb69bf6aa4ed26b2bf8c322ae05bef0bcc5c10"));
-		commits.add(c1);
-		
-		ValidationRequest vr = new ValidationRequest();
-		vr.setProvider(ProviderType.GITHUB);
-		vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/sample"));
-		vr.setCommits(commits);
-		// test output w/ assertions
-		// Error should be singular + that there's no Eclipse Account on file for committer
-		// Status 403 (forbidden) is the standard return for invalid requests
-		given()
-			.body(vr)
-			.contentType(ContentType.JSON)
-				.when().post("/eca")
-				.then()
-					.statusCode(403)
-					.body("passed", is(false),
-							"errorCount", is(1));
-	}
+    ValidationRequest vr = new ValidationRequest();
+    vr.setProvider(ProviderType.GITHUB);
+    vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/prototype"));
+    vr.setCommits(commits);
+
+    // test output w/ assertions
+    // Should be invalid as a different email was associated with the footer
+    given()
+        .body(vr)
+        .contentType(ContentType.JSON)
+        .when()
+        .post("/eca")
+        .then()
+        .statusCode(403)
+        .body(
+            "passed",
+            is(false),
+            "errorCount",
+            is(1),
+            "commits.123456789abcdefghijklmnop.errors[0].code",
+            is(APIStatusCode.ERROR_SIGN_OFF.getValue()));
+  }
+
+  @Test
+  void validateCommitSignOffMultipleFooterLines_Last() throws URISyntaxException {
+    // set up test users
+    GitUser g1 = new GitUser();
+    g1.setName("Barshall Blathers");
+    g1.setMail("slom@eclipse-foundation.org");
+
+    List<Commit> commits = new ArrayList<>();
+    // create sample commits
+    Commit c1 = new Commit();
+    c1.setAuthor(g1);
+    c1.setCommitter(g1);
+    c1.setBody(
+        String.format(
+            "Change-Id: 0000000000000001\nSigned-off-by: %s <%s>", g1.getName(), g1.getMail()));
+    c1.setHash("123456789abcdefghijklmnop");
+    c1.setSubject("All of the things");
+    c1.setParents(Collections.emptyList());
+    commits.add(c1);
+
+    ValidationRequest vr = new ValidationRequest();
+    vr.setProvider(ProviderType.GITHUB);
+    vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/prototype"));
+    vr.setCommits(commits);
+
+    // test output w/ assertions
+    given()
+        .body(vr)
+        .contentType(ContentType.JSON)
+        .when()
+        .post("/eca")
+        .then()
+        .statusCode(200)
+        .body("passed", is(true), "errorCount", is(0));
+  }
+
+  @Test
+  void validateCommitSignOffMultipleFooterLines_First() throws URISyntaxException {
+    // set up test users
+    GitUser g1 = new GitUser();
+    g1.setName("Barshall Blathers");
+    g1.setMail("slom@eclipse-foundation.org");
+
+    List<Commit> commits = new ArrayList<>();
+    // create sample commits
+    Commit c1 = new Commit();
+    c1.setAuthor(g1);
+    c1.setCommitter(g1);
+    c1.setBody(
+        String.format(
+            "Signed-off-by: %s <%s>\nChange-Id: 0000000000000001", g1.getName(), g1.getMail()));
+    c1.setHash("123456789abcdefghijklmnop");
+    c1.setSubject("All of the things");
+    c1.setParents(Collections.emptyList());
+    commits.add(c1);
+
+    ValidationRequest vr = new ValidationRequest();
+    vr.setProvider(ProviderType.GITHUB);
+    vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/prototype"));
+    vr.setCommits(commits);
+
+    // test output w/ assertions
+    given()
+        .body(vr)
+        .contentType(ContentType.JSON)
+        .when()
+        .post("/eca")
+        .then()
+        .statusCode(200)
+        .body("passed", is(true), "errorCount", is(0));
+  }
+
+  @Test
+  void validateCommitSignOffMultipleFooterLines_Multiple() throws URISyntaxException {
+    // set up test users
+    GitUser g1 = new GitUser();
+    g1.setName("Barshall Blathers");
+    g1.setMail("slom@eclipse-foundation.org");
+
+    List<Commit> commits = new ArrayList<>();
+    // create sample commits
+    Commit c1 = new Commit();
+    c1.setAuthor(g1);
+    c1.setCommitter(g1);
+    c1.setBody(
+        String.format(
+            "Change-Id: 0000000000000001\\nSigned-off-by: %s <%s>\nSigned-off-by: %s <%s>",
+            g1.getName(), g1.getMail(), g1.getName(), "barshallb@personal.co"));
+    c1.setHash("123456789abcdefghijklmnop");
+    c1.setSubject("All of the things");
+    c1.setParents(Collections.emptyList());
+    commits.add(c1);
+
+    ValidationRequest vr = new ValidationRequest();
+    vr.setProvider(ProviderType.GITHUB);
+    vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/prototype"));
+    vr.setCommits(commits);
+
+    // test output w/ assertions
+    given()
+        .body(vr)
+        .contentType(ContentType.JSON)
+        .when()
+        .post("/eca")
+        .then()
+        .statusCode(200)
+        .body("passed", is(true), "errorCount", is(0));
+  }
+
+  @Test
+  void validateWorkingGroupSpecAccess() throws URISyntaxException {
+    // set up test users
+    GitUser g1 = new GitUser();
+    g1.setName("The Wizard");
+    g1.setMail("code.wiz@important.co");
+
+    GitUser g2 = new GitUser();
+    g2.setName("Grunts McGee");
+    g2.setMail("grunt@important.co");
+
+    // CASE 1: WG Spec project write access valid
+    List<Commit> commits = new ArrayList<>();
+    // create sample commits
+    Commit c1 = new Commit();
+    c1.setAuthor(g1);
+    c1.setCommitter(g1);
+    c1.setBody("Signed-off-by: The Wizard <code.wiz@important.co>");
+    c1.setHash("123456789abcdefghijklmnop");
+    c1.setSubject("All of the things");
+    c1.setParents(Collections.emptyList());
+    commits.add(c1);
+
+    ValidationRequest vr = new ValidationRequest();
+    vr.setProvider(ProviderType.GITHUB);
+    vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/tck-proto"));
+    vr.setCommits(commits);
+
+    // test output w/ assertions
+    // Should be valid as Wizard has spec project write access + is committer
+    given()
+        .body(vr)
+        .contentType(ContentType.JSON)
+        .when()
+        .post("/eca")
+        .then()
+        .statusCode(200)
+        .body("passed", is(true), "errorCount", is(0));
+
+    // CASE 2: No WG Spec proj write access
+    commits = new ArrayList<>();
+    // create sample commits
+    c1 = new Commit();
+    c1.setAuthor(g2);
+    c1.setCommitter(g2);
+    c1.setBody(String.format("Signed-off-by: %s <%s>", g2.getName(), g2.getMail()));
+    c1.setHash("123456789abcdefghijklmnop");
+    c1.setSubject("All of the things");
+    c1.setParents(Arrays.asList("46bb69bf6aa4ed26b2bf8c322ae05bef0bcc5c10"));
+    commits.add(c1);
+
+    vr = new ValidationRequest();
+    vr.setProvider(ProviderType.GITHUB);
+    vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/tck-proto"));
+    vr.setCommits(commits);
+
+    // test output w/ assertions
+    // Should be invalid as Grunt does not have spec project write access
+    given()
+        .body(vr)
+        .contentType(ContentType.JSON)
+        .when()
+        .post("/eca")
+        .then()
+        .statusCode(403)
+        .body(
+            "passed",
+            is(false),
+            "errorCount",
+            is(1),
+            "commits.123456789abcdefghijklmnop.errors[0].code",
+            is(APIStatusCode.ERROR_SPEC_PROJECT.getValue()));
+  }
+
+  @Test
+  void validateProxyCommitPush() throws URISyntaxException {
+    // set up test users
+    GitUser g1 = new GitUser();
+    g1.setName("The Wizard");
+    g1.setMail("code.wiz@important.co");
+
+    GitUser g2 = new GitUser();
+    g2.setName("Barshall Blathers");
+    g2.setMail("slom@eclipse-foundation.org");
+
+    // CASE 1: Committer pushing for non-committer author
+    List<Commit> commits = new ArrayList<>();
+    // create sample commits
+    Commit c1 = new Commit();
+    c1.setAuthor(g2);
+    c1.setCommitter(g1);
+    c1.setBody(String.format("Signed-off-by: %s <%s>", g2.getName(), g2.getMail()));
+    c1.setHash("123456789abcdefghijklmnop");
+    c1.setSubject("All of the things");
+    c1.setParents(Collections.emptyList());
+    commits.add(c1);
+
+    ValidationRequest vr = new ValidationRequest();
+    vr.setProvider(ProviderType.GITHUB);
+    vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/tck-proto"));
+    vr.setCommits(commits);
+
+    // test output w/ assertions
+    // Should be valid as Wizard is a committer on proj
+    given()
+        .body(vr)
+        .contentType(ContentType.JSON)
+        .when()
+        .post("/eca")
+        .then()
+        .statusCode(200)
+        .body("passed", is(true), "errorCount", is(0));
+
+    // CASE 2: Non-committer pushing for non-committer author
+    commits = new ArrayList<>();
+    // create sample commits
+    c1 = new Commit();
+    c1.setAuthor(g2);
+    c1.setCommitter(g1);
+    c1.setBody(String.format("Signed-off-by: %s <%s>", g2.getName(), g2.getMail()));
+    c1.setHash("123456789abcdefghijklmnop");
+    c1.setSubject("All of the things");
+    c1.setParents(Arrays.asList("46bb69bf6aa4ed26b2bf8c322ae05bef0bcc5c10"));
+    commits.add(c1);
+
+    vr = new ValidationRequest();
+    vr.setProvider(ProviderType.GITHUB);
+    vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/prototype"));
+    vr.setCommits(commits);
+
+    // test output w/ assertions
+    // Should be invalid as Wizard is not a committer on proj
+    given()
+        .body(vr)
+        .contentType(ContentType.JSON)
+        .when()
+        .post("/eca")
+        .then()
+        .statusCode(403)
+        .body("passed", is(false), "errorCount", is(1));
+  }
+
+  @Test
+  void validateNoECA() throws URISyntaxException {
+    // set up test users
+    GitUser g1 = new GitUser();
+    g1.setName("Newbie Anon");
+    g1.setMail("newbie@important.co");
+
+    List<Commit> commits = new ArrayList<>();
+    // create sample commits
+    Commit c1 = new Commit();
+    c1.setAuthor(g1);
+    c1.setCommitter(g1);
+    c1.setBody(String.format("Signed-off-by: %s <%s>", g1.getName(), g1.getMail()));
+    c1.setHash("123456789abcdefghijklmnop");
+    c1.setSubject("All of the things");
+    c1.setParents(Arrays.asList("46bb69bf6aa4ed26b2bf8c322ae05bef0bcc5c10"));
+    commits.add(c1);
+
+    ValidationRequest vr = new ValidationRequest();
+    vr.setProvider(ProviderType.GITHUB);
+    vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/sample"));
+    vr.setCommits(commits);
+    // test output w/ assertions
+    // Error should be singular + that there's no ECA on file
+    // Status 403 (forbidden) is the standard return for invalid requests
+    given()
+        .body(vr)
+        .contentType(ContentType.JSON)
+        .when()
+        .post("/eca")
+        .then()
+        .statusCode(403)
+        .body("passed", is(false), "errorCount", is(1));
+  }
+
+  @Test
+  void validateAuthorNoEclipseAccount() throws URISyntaxException {
+    // set up test users
+    GitUser g1 = new GitUser();
+    g1.setName("Rando Calressian");
+    g1.setMail("rando@nowhere.co");
+
+    GitUser g2 = new GitUser();
+    g2.setName("Grunts McGee");
+    g2.setMail("grunt@important.co");
+
+    List<Commit> commits = new ArrayList<>();
+    // create sample commits
+    Commit c1 = new Commit();
+    c1.setAuthor(g1);
+    c1.setCommitter(g2);
+    c1.setBody(String.format("Signed-off-by: %s <%s>", g1.getName(), g1.getMail()));
+    c1.setHash("123456789abcdefghijklmnop");
+    c1.setSubject("All of the things");
+    c1.setParents(Arrays.asList("46bb69bf6aa4ed26b2bf8c322ae05bef0bcc5c10"));
+    commits.add(c1);
+
+    ValidationRequest vr = new ValidationRequest();
+    vr.setProvider(ProviderType.GITHUB);
+    vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/sample"));
+    vr.setCommits(commits);
+    // test output w/ assertions
+    // Error should be singular + that there's no Eclipse Account on file for author
+    // Status 403 (forbidden) is the standard return for invalid requests
+    given()
+        .body(vr)
+        .contentType(ContentType.JSON)
+        .when()
+        .post("/eca")
+        .then()
+        .statusCode(403)
+        .body("passed", is(false), "errorCount", is(1));
+  }
+
+  @Test
+  void validateCommitterNoEclipseAccount() throws URISyntaxException {
+    // set up test users
+    GitUser g1 = new GitUser();
+    g1.setName("Rando Calressian");
+    g1.setMail("rando@nowhere.co");
+
+    GitUser g2 = new GitUser();
+    g2.setName("Grunts McGee");
+    g2.setMail("grunt@important.co");
+
+    List<Commit> commits = new ArrayList<>();
+    // create sample commits
+    Commit c1 = new Commit();
+    c1.setAuthor(g2);
+    c1.setCommitter(g1);
+    c1.setBody(String.format("Signed-off-by: %s <%s>", g2.getName(), g2.getMail()));
+    c1.setHash("123456789abcdefghijklmnop");
+    c1.setSubject("All of the things");
+    c1.setParents(Arrays.asList("46bb69bf6aa4ed26b2bf8c322ae05bef0bcc5c10"));
+    commits.add(c1);
+
+    ValidationRequest vr = new ValidationRequest();
+    vr.setProvider(ProviderType.GITHUB);
+    vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/sample"));
+    vr.setCommits(commits);
+    // test output w/ assertions
+    // Error should be singular + that there's no Eclipse Account on file for committer
+    // Status 403 (forbidden) is the standard return for invalid requests
+    given()
+        .body(vr)
+        .contentType(ContentType.JSON)
+        .when()
+        .post("/eca")
+        .then()
+        .statusCode(403)
+        .body("passed", is(false), "errorCount", is(1));
+  }
 }


### PR DESCRIPTION
CommitHelper now checks multiple footerlines for matching email rather
than first only.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>