### PR TITLE
Change that will bypass committer check if not a PMI project

### DIFF
--- a/src/main/java/org/eclipsefoundation/git/eca/resource/ValidationResource.java
+++ b/src/main/java/org/eclipsefoundation/git/eca/resource/ValidationResource.java
@@ -187,7 +187,7 @@ public class ValidationResource {
     validateAuthorAccess(response, c, eclipseAuthor, filteredProjects);
 
     // only committers can push on behalf of other users
-    if (!eclipseAuthor.equals(eclipseCommitter)
+    if (response.isTrackedProject() && !eclipseAuthor.equals(eclipseCommitter)
         && !isCommitter(response, eclipseCommitter, c.getHash(), filteredProjects)) {
       addMessage(response, "You are not a project committer.", c.getHash());
       addMessage(response, "Only project committers can push on behalf of others.", c.getHash());


### PR DESCRIPTION
Currently this causes issues on internal checks, but could cause issues
rebasing in some scenarios in other environments.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>