### PR TITLE
Change bot detection logic and add tests around bot detection in API

### DIFF
--- a/src/main/java/org/eclipsefoundation/git/eca/model/BotUser.java
+++ b/src/main/java/org/eclipsefoundation/git/eca/model/BotUser.java
@@ -1,80 +1,118 @@
-/*******************************************************************************
+/**
  * Copyright (C) 2020 Eclipse Foundation
- * 
- * This program and the accompanying materials are made
- * available under the terms of the Eclipse Public License 2.0
- * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
- ******************************************************************************/
+ *
+ * <p>This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License 2.0 which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * <p>SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipsefoundation.git.eca.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Represents a bot user in the Eclipse API.
- * 
- * @author Martin Lowe
  *
+ * @author Martin Lowe
  */
 public class BotUser {
-	private String id;
-	private String projectId;
-	private String username;
-	private String email;
+  private String id;
+  private String projectId;
+  private String username;
+  private String email;
+  @JsonProperty("github.com")
+  private SiteSpecificBot githubBot;
+  @JsonProperty("gitlab.eclipse.org")
+  private SiteSpecificBot gitlabBot;
 
-	/**
-	 * @return the id
-	 */
-	public String getId() {
-		return id;
-	}
+  /** @return the id */
+  public String getId() {
+    return id;
+  }
 
-	/**
-	 * @param id the id to set
-	 */
-	public void setId(String id) {
-		this.id = id;
-	}
+  /** @param id the id to set */
+  public void setId(String id) {
+    this.id = id;
+  }
 
-	/**
-	 * @return the projectId
-	 */
-	public String getProjectId() {
-		return projectId;
-	}
+  /** @return the projectId */
+  public String getProjectId() {
+    return projectId;
+  }
 
-	/**
-	 * @param projectId the projectId to set
-	 */
-	public void setProjectId(String projectId) {
-		this.projectId = projectId;
-	}
+  /** @param projectId the projectId to set */
+  public void setProjectId(String projectId) {
+    this.projectId = projectId;
+  }
 
-	/**
-	 * @return the username
-	 */
-	public String getUsername() {
-		return username;
-	}
+  /** @return the username */
+  public String getUsername() {
+    return username;
+  }
 
-	/**
-	 * @param username the username to set
-	 */
-	public void setUsername(String username) {
-		this.username = username;
-	}
+  /** @param username the username to set */
+  public void setUsername(String username) {
+    this.username = username;
+  }
 
-	/**
-	 * @return the email
-	 */
-	public String getEmail() {
-		return email;
-	}
+  /** @return the email */
+  public String getEmail() {
+    return email;
+  }
 
-	/**
-	 * @param email the email to set
-	 */
-	public void setEmail(String email) {
-		this.email = email;
-	}
+  /**
+ * @return the githubBot
+ */
+public SiteSpecificBot getGithubBot() {
+return githubBot;}
 
+/**
+ * @param githubBot the githubBot to set
+ */
+public void setGithubBot(SiteSpecificBot githubBot) {
+this.githubBot = githubBot;}
+
+/**
+ * @return the gitlabBot
+ */
+public SiteSpecificBot getGitlabBot() {
+return gitlabBot;}
+
+/**
+ * @param gitlabBot the gitlabBot to set
+ */
+public void setGitlabBot(SiteSpecificBot gitlabBot) {
+this.gitlabBot = gitlabBot;}
+
+/** @param email the email to set */
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+  @Override public String toString(){StringBuilder builder=new StringBuilder();builder.append("BotUser [id=");builder.append(id);builder.append(", projectId=");builder.append(projectId);builder.append(", username=");builder.append(username);builder.append(", email=");builder.append(email);builder.append(", githubBot=");builder.append(githubBot);builder.append(", gitlabBot=");builder.append(gitlabBot);builder.append("]");return builder.toString();}
+
+public static class SiteSpecificBot {
+    private String username;
+    private String email;
+
+    /** @return the username */
+    public String getUsername() {
+      return username;
+    }
+
+    /** @param username the username to set */
+    public void setUsername(String username) {
+      this.username = username;
+    }
+
+    /** @return the email */
+    public String getEmail() {
+      return email;
+    }
+
+    /** @param email the email to set */
+    public void setEmail(String email) {
+      this.email = email;
+    }
+  }
 }

--- a/src/main/java/org/eclipsefoundation/git/eca/model/BotUser.java
+++ b/src/main/java/org/eclipsefoundation/git/eca/model/BotUser.java
@@ -20,8 +20,10 @@ public class BotUser {
   private String projectId;
   private String username;
   private String email;
+
   @JsonProperty("github.com")
   private SiteSpecificBot githubBot;
+
   @JsonProperty("gitlab.eclipse.org")
   private SiteSpecificBot gitlabBot;
 
@@ -60,38 +62,51 @@ public class BotUser {
     return email;
   }
 
-  /**
- * @return the githubBot
- */
-public SiteSpecificBot getGithubBot() {
-return githubBot;}
+  /** @return the githubBot */
+  public SiteSpecificBot getGithubBot() {
+    return githubBot;
+  }
 
-/**
- * @param githubBot the githubBot to set
- */
-public void setGithubBot(SiteSpecificBot githubBot) {
-this.githubBot = githubBot;}
+  /** @param githubBot the githubBot to set */
+  public void setGithubBot(SiteSpecificBot githubBot) {
+    this.githubBot = githubBot;
+  }
 
-/**
- * @return the gitlabBot
- */
-public SiteSpecificBot getGitlabBot() {
-return gitlabBot;}
+  /** @return the gitlabBot */
+  public SiteSpecificBot getGitlabBot() {
+    return gitlabBot;
+  }
 
-/**
- * @param gitlabBot the gitlabBot to set
- */
-public void setGitlabBot(SiteSpecificBot gitlabBot) {
-this.gitlabBot = gitlabBot;}
+  /** @param gitlabBot the gitlabBot to set */
+  public void setGitlabBot(SiteSpecificBot gitlabBot) {
+    this.gitlabBot = gitlabBot;
+  }
 
-/** @param email the email to set */
+  /** @param email the email to set */
   public void setEmail(String email) {
     this.email = email;
   }
 
-  @Override public String toString(){StringBuilder builder=new StringBuilder();builder.append("BotUser [id=");builder.append(id);builder.append(", projectId=");builder.append(projectId);builder.append(", username=");builder.append(username);builder.append(", email=");builder.append(email);builder.append(", githubBot=");builder.append(githubBot);builder.append(", gitlabBot=");builder.append(gitlabBot);builder.append("]");return builder.toString();}
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("BotUser [id=");
+    builder.append(id);
+    builder.append(", projectId=");
+    builder.append(projectId);
+    builder.append(", username=");
+    builder.append(username);
+    builder.append(", email=");
+    builder.append(email);
+    builder.append(", githubBot=");
+    builder.append(githubBot);
+    builder.append(", gitlabBot=");
+    builder.append(gitlabBot);
+    builder.append("]");
+    return builder.toString();
+  }
 
-public static class SiteSpecificBot {
+  public static class SiteSpecificBot {
     private String username;
     private String email;
 

--- a/src/main/java/org/eclipsefoundation/git/eca/model/EclipseUser.java
+++ b/src/main/java/org/eclipsefoundation/git/eca/model/EclipseUser.java
@@ -1,144 +1,161 @@
-/*******************************************************************************
+/**
  * Copyright (C) 2020 Eclipse Foundation
- * 
- * This program and the accompanying materials are made
- * available under the terms of the Eclipse Public License 2.0
- * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
- * SPDX-License-Identifier: EPL-2.0
- ******************************************************************************/
+ *
+ * <p>This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License 2.0 which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * <p>SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipsefoundation.git.eca.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 /**
  * Represents a users Eclipse Foundation account
- * 
- * @author Martin Lowe
  *
+ * @author Martin Lowe
  */
 public class EclipseUser {
-	private int uid;
-	private String name;
-	private String mail;
-	private ECA eca;
-	private boolean isCommitter;
+  private int uid;
+  private String name;
+  private String mail;
+  private ECA eca;
+  private boolean isCommitter;
+  // this field is internal for tracking bot stubs
+  @JsonIgnore private boolean isBot;
 
-	/**
-	 * @return the id
-	 */
-	public int getId() {
-		return uid;
-	}
+  /**
+   * Create a bot user stub when there is no real Eclipse account for the bot.
+   *
+   * @param user the Git user that was detected to be a bot.
+   * @return a stubbed Eclipse user bot object.
+   */
+  public static EclipseUser createBotStub(GitUser user) {
+    EclipseUser stub = new EclipseUser();
+    stub.setName(user.getName());
+    stub.setMail(user.getMail());
+    stub.setEca(new ECA());
+    stub.setBot(true);
+    return stub;
+  }
 
-	/**
-	 * @param id the id to set
-	 */
-	public void setId(int uid) {
-		this.uid = uid;
-	}
+  /** @return the id */
+  public int getId() {
+    return uid;
+  }
 
-	/**
-	 * @return the name
-	 */
-	public String getName() {
-		return name;
-	}
+  /** @param id the id to set */
+  public void setId(int uid) {
+    this.uid = uid;
+  }
 
-	/**
-	 * @param name the name to set
-	 */
-	public void setName(String name) {
-		this.name = name;
-	}
+  /** @return the name */
+  public String getName() {
+    return name;
+  }
 
-	/**
-	 * @return the mail
-	 */
-	public String getMail() {
-		return mail;
-	}
+  /** @param name the name to set */
+  public void setName(String name) {
+    this.name = name;
+  }
 
-	/**
-	 * @param mail the mail to set
-	 */
-	public void setMail(String mail) {
-		this.mail = mail;
-	}
+  /** @return the mail */
+  public String getMail() {
+    return mail;
+  }
 
-	/**
-	 * @return the eca
-	 */
-	public ECA getEca() {
-		return eca;
-	}
+  /** @param mail the mail to set */
+  public void setMail(String mail) {
+    this.mail = mail;
+  }
 
-	/**
-	 * @param eca the eca to set
-	 */
-	public void setEca(ECA eca) {
-		this.eca = eca;
-	}
+  /** @return the eca */
+  public ECA getEca() {
+    return eca;
+  }
 
-	/**
-	 * @return the isCommitter
-	 */
-	public boolean isCommitter() {
-		return isCommitter;
-	}
+  /** @param eca the eca to set */
+  public void setEca(ECA eca) {
+    this.eca = eca;
+  }
 
-	/**
-	 * @param isCommitter the isCommitter to set
-	 */
-	public void setCommitter(boolean isCommitter) {
-		this.isCommitter = isCommitter;
-	}
+  /** @return the isCommitter */
+  public boolean isCommitter() {
+    return isCommitter;
+  }
 
-	/**
-	 * ECA for Eclipse accounts, representing whether users have signed the Eclipse
-	 * Committer Agreement to enable contribution.
-	 */
-	@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-	public static class ECA {
-		private boolean signed;
-		private boolean canContributeSpecProject;
-		
-		public ECA() {
-			this(false, false);
-		}
-		
-		public ECA(boolean signed, boolean canContributeSpecProject) {
-			this.signed = signed;
-			this.canContributeSpecProject = canContributeSpecProject;
-		}
+  /** @param isCommitter the isCommitter to set */
+  public void setCommitter(boolean isCommitter) {
+    this.isCommitter = isCommitter;
+  }
 
-		/**
-		 * @return the signed
-		 */
-		public boolean isSigned() {
-			return signed;
-		}
+  /** @return the isBot */
+  public boolean isBot() {
+    return isBot;
+  }
 
-		/**
-		 * @param signed the signed to set
-		 */
-		public void setSigned(boolean signed) {
-			this.signed = signed;
-		}
+  /** @param isBot the isBot to set */
+  private void setBot(boolean isBot) {
+    this.isBot = isBot;
+  }
 
-		/**
-		 * @return the canContributeSpecProject
-		 */
-		public boolean isCanContributeSpecProject() {
-			return canContributeSpecProject;
-		}
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("EclipseUser [uid=");
+    builder.append(uid);
+    builder.append(", name=");
+    builder.append(name);
+    builder.append(", mail=");
+    builder.append(mail);
+    builder.append(", eca=");
+    builder.append(eca);
+    builder.append(", isCommitter=");
+    builder.append(isCommitter);
+    builder.append(", isBot=");
+    builder.append(isBot);
+    builder.append("]");
+    return builder.toString();
+  }
 
-		/**
-		 * @param canContributeSpecProject the canContributeSpecProject to set
-		 */
-		public void setCanContributeSpecProject(boolean canContributeSpecProject) {
-			this.canContributeSpecProject = canContributeSpecProject;
-		}
-	}
+  /**
+   * ECA for Eclipse accounts, representing whether users have signed the Eclipse Committer
+   * Agreement to enable contribution.
+   */
+  @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+  public static class ECA {
+    private boolean signed;
+    private boolean canContributeSpecProject;
+
+    public ECA() {
+      this(false, false);
+    }
+
+    public ECA(boolean signed, boolean canContributeSpecProject) {
+      this.signed = signed;
+      this.canContributeSpecProject = canContributeSpecProject;
+    }
+
+    /** @return the signed */
+    public boolean isSigned() {
+      return signed;
+    }
+
+    /** @param signed the signed to set */
+    public void setSigned(boolean signed) {
+      this.signed = signed;
+    }
+
+    /** @return the canContributeSpecProject */
+    public boolean isCanContributeSpecProject() {
+      return canContributeSpecProject;
+    }
+
+    /** @param canContributeSpecProject the canContributeSpecProject to set */
+    public void setCanContributeSpecProject(boolean canContributeSpecProject) {
+      this.canContributeSpecProject = canContributeSpecProject;
+    }
+  }
 }

--- a/src/main/java/org/eclipsefoundation/git/eca/resource/ValidationResource.java
+++ b/src/main/java/org/eclipsefoundation/git/eca/resource/ValidationResource.java
@@ -415,7 +415,7 @@ public class ValidationResource {
   private List<BotUser> getBots() {
     Optional<List<BotUser>> allBots =
         cache.get("allBots", () -> bots.getBots(), (Class<List<BotUser>>) (Object) List.class);
-    if (allBots.isEmpty()) {
+    if (!allBots.isPresent()) {
       return Collections.emptyList();
     }
     return allBots.get();

--- a/src/test/java/org/eclipsefoundation/git/eca/api/MockBotsAPI.java
+++ b/src/test/java/org/eclipsefoundation/git/eca/api/MockBotsAPI.java
@@ -17,6 +17,7 @@ import javax.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.eclipsefoundation.git.eca.model.BotUser;
+import org.eclipsefoundation.git.eca.model.BotUser.SiteSpecificBot;
 
 import io.quarkus.test.Mock;
 
@@ -42,6 +43,10 @@ public class MockBotsAPI implements BotsAPI {
 		b2.setEmail("2.bot@eclipse.org");
 		b2.setProjectId("sample.proto");
 		b2.setUsername("protobot");
+		SiteSpecificBot ssbGH = new SiteSpecificBot();
+		ssbGH.setEmail("2.bot-github@eclipse.org");
+		ssbGH.setUsername("protobot-gh");
+		b2.setGithubBot(ssbGH);
 		src.add(b2);
 		
 		BotUser b3 = new BotUser();
@@ -49,6 +54,10 @@ public class MockBotsAPI implements BotsAPI {
 		b3.setEmail("3.bot@eclipse.org");
 		b3.setProjectId("spec.proj");
 		b3.setUsername("specbot");
+		SiteSpecificBot ssbGL = new SiteSpecificBot();
+		ssbGL.setEmail("3.bot-gitlab@eclipse.org");
+		ssbGL.setUsername("protobot-gl");
+		b3.setGitlabBot(ssbGL);
 		src.add(b3);
 	}
 

--- a/src/test/java/org/eclipsefoundation/git/eca/resource/ValidationResourceTest.java
+++ b/src/test/java/org/eclipsefoundation/git/eca/resource/ValidationResourceTest.java
@@ -1,12 +1,10 @@
 /**
- * Copyright (C) 2020
- * Eclipse Foundation
+ * Copyright (C) 2020 Eclipse Foundation
  *
  * <p>This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License 2.0 which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * <p>SPDX-License-Identifier: EPL-2.0
- * 
  */
 package org.eclipsefoundation.git.eca.resource;
 
@@ -665,14 +663,165 @@ class ValidationResourceTest {
     vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/sample-not-tracked"));
     vr.setCommits(commits);
     // test output w/ assertions
-    // Error should be singular + that there's no Eclipse Account on file for committer
-    // Status 403 (forbidden) is the standard return for invalid requests
-    given()
-        .body(vr)
-        .contentType(ContentType.JSON)
-        .when()
-        .post("/eca")
-        .then()
-        .statusCode(200);
+    // Should be valid as project is not tracked
+    given().body(vr).contentType(ContentType.JSON).when().post("/eca").then().statusCode(200);
+  }
+
+  @Test
+  void validateBotCommiterAccessGithub() throws URISyntaxException {
+    // set up test users
+    GitUser g1 = new GitUser();
+    g1.setName("protobot-gh");
+    g1.setMail("2.bot-github@eclipse.org");
+
+    List<Commit> commits = new ArrayList<>();
+    // create sample commits
+    Commit c1 = new Commit();
+    c1.setAuthor(g1);
+    c1.setCommitter(g1);
+    c1.setHash("123456789abcdefghijklmnop");
+    c1.setSubject("All of the things");
+    c1.setParents(Arrays.asList("46bb69bf6aa4ed26b2bf8c322ae05bef0bcc5c10"));
+    commits.add(c1);
+
+    ValidationRequest vr = new ValidationRequest();
+    vr.setProvider(ProviderType.GITHUB);
+    vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/sample"));
+    vr.setCommits(commits);
+    // test output w/ assertions
+    // Should be valid as bots don't need sign off and should be valid on any proj
+    given().body(vr).contentType(ContentType.JSON).when().post("/eca").then().statusCode(200);
+  }
+
+  @Test
+  void validateBotCommiterAccessGithub_wrongEmail() throws URISyntaxException {
+    // set up test users - uses Gerrit/LDAP email (wrong for case)
+    GitUser g1 = new GitUser();
+    g1.setName("protobot");
+    g1.setMail("2.bot@eclipse.org");
+
+    List<Commit> commits = new ArrayList<>();
+    // create sample commits
+    Commit c1 = new Commit();
+    c1.setAuthor(g1);
+    c1.setCommitter(g1);
+    c1.setHash("123456789abcdefghijklmnop");
+    c1.setSubject("All of the things");
+    c1.setParents(Arrays.asList("46bb69bf6aa4ed26b2bf8c322ae05bef0bcc5c10"));
+    commits.add(c1);
+
+    ValidationRequest vr = new ValidationRequest();
+    vr.setProvider(ProviderType.GITHUB);
+    vr.setRepoUrl(new URI("http://www.github.com/eclipsefdn/sample"));
+    vr.setCommits(commits);
+    // test output w/ assertions
+    // Should be invalid as wrong email was used for bot (uses Gerrit bot email)
+    given().body(vr).contentType(ContentType.JSON).when().post("/eca").then().statusCode(403);
+  }
+
+  @Test
+  void validateBotCommiterAccessGitlab() throws URISyntaxException {
+    // set up test users
+    GitUser g1 = new GitUser();
+    g1.setName("specbot-gh");
+    g1.setMail("3.bot-gitlab@eclipse.org");
+
+    List<Commit> commits = new ArrayList<>();
+    // create sample commits
+    Commit c1 = new Commit();
+    c1.setAuthor(g1);
+    c1.setCommitter(g1);
+    c1.setHash("123456789abcdefghijklmnop");
+    c1.setSubject("All of the things");
+    c1.setParents(Arrays.asList("46bb69bf6aa4ed26b2bf8c322ae05bef0bcc5c10"));
+    commits.add(c1);
+
+    ValidationRequest vr = new ValidationRequest();
+    vr.setProvider(ProviderType.GITLAB);
+    vr.setRepoUrl(new URI("https://gitlab.eclipse.org/eclipse/dash/dash.handbook.test"));
+    vr.setCommits(commits);
+    // test output w/ assertions
+    // Should be valid as bots don't need sign off and should be valid on any proj
+    given().body(vr).contentType(ContentType.JSON).when().post("/eca").then().statusCode(200);
+  }
+
+  @Test
+  void validateBotCommiterAccessGitlab_wrongEmail() throws URISyntaxException {
+    // set up test users - uses Gerrit/LDAP email (wrong for case)
+    GitUser g1 = new GitUser();
+    g1.setName("specbot");
+    g1.setMail("3.bot@eclipse.org");
+
+    List<Commit> commits = new ArrayList<>();
+    // create sample commits
+    Commit c1 = new Commit();
+    c1.setAuthor(g1);
+    c1.setCommitter(g1);
+    c1.setHash("123456789abcdefghijklmnop");
+    c1.setSubject("All of the things");
+    c1.setParents(Arrays.asList("46bb69bf6aa4ed26b2bf8c322ae05bef0bcc5c10"));
+    commits.add(c1);
+
+    ValidationRequest vr = new ValidationRequest();
+    vr.setProvider(ProviderType.GITLAB);
+    vr.setRepoUrl(new URI("https://gitlab.eclipse.org/eclipse/dash/dash.git"));
+    vr.setCommits(commits);
+    // test output w/ assertions
+    // Should be invalid as wrong email was used for bot (uses Gerrit bot email)
+    given().body(vr).contentType(ContentType.JSON).when().post("/eca").then().statusCode(403);
+  }
+
+  @Test
+  void validateBotCommiterAccessGerrit() throws URISyntaxException {
+    // set up test users
+    GitUser g1 = new GitUser();
+    g1.setName("protobot");
+    g1.setMail("2.bot@eclipse.org");
+
+    List<Commit> commits = new ArrayList<>();
+    // create sample commits
+    Commit c1 = new Commit();
+    c1.setAuthor(g1);
+    c1.setCommitter(g1);
+    c1.setHash("123456789abcdefghijklmnop");
+    c1.setSubject("All of the things");
+    c1.setParents(Arrays.asList("46bb69bf6aa4ed26b2bf8c322ae05bef0bcc5c10"));
+    commits.add(c1);
+
+    ValidationRequest vr = new ValidationRequest();
+    vr.setProvider(ProviderType.GERRIT);
+    vr.setRepoUrl(new URI("/gitroot/sample/gerrit.other-project"));
+    vr.setCommits(commits);
+    vr.setStrictMode(true);
+    // test output w/ assertions
+    // Should be valid as bots don't need sign off and should be valid on any proj
+    given().body(vr).contentType(ContentType.JSON).when().post("/eca").then().statusCode(200);
+  }
+
+  @Test
+  void validateBotCommiterAccessGerrit_wrongEmail() throws URISyntaxException {
+    // set up test users - uses Gerrit/LDAP email (wrong for case)
+    GitUser g1 = new GitUser();
+    g1.setName("protobot-gh");
+    g1.setMail("2.bot-github@eclipse.org");
+
+    List<Commit> commits = new ArrayList<>();
+    // create sample commits
+    Commit c1 = new Commit();
+    c1.setAuthor(g1);
+    c1.setCommitter(g1);
+    c1.setHash("123456789abcdefghijklmnop");
+    c1.setSubject("All of the things");
+    c1.setParents(Arrays.asList("46bb69bf6aa4ed26b2bf8c322ae05bef0bcc5c10"));
+    commits.add(c1);
+
+    ValidationRequest vr = new ValidationRequest();
+    vr.setProvider(ProviderType.GERRIT);
+    vr.setRepoUrl(new URI("/gitroot/sample/gerrit.other-project"));
+    vr.setCommits(commits);
+    vr.setStrictMode(true);
+    // test output w/ assertions
+    // Should be invalid as wrong email was used for bot (uses Gerrit bot email)
+    given().body(vr).contentType(ContentType.JSON).when().post("/eca").then().statusCode(403);
   }
 }


### PR DESCRIPTION
Added tests for all 3 supported platforms (Github, Gitlab, and Gerrit)
around bot detection. Changed bot detection policy to check if user is
any bot, regardless of project commit is for. This allows for bots to
push in untracked projects when using strict mode as well.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>